### PR TITLE
Added a speaker deck showing next slide and notes

### DIFF
--- a/asciidoc/asciidoctor-backends/haml/deckjs/block_admonition.html.haml
+++ b/asciidoc/asciidoctor-backends/haml/deckjs/block_admonition.html.haml
@@ -1,14 +1,2 @@
-%div{:id=>@id, :class=>['admonitionblock', (attr :name), role]}
-  %table
-    %tr
-      %td.icon
-        - if @document.attr? :icons, 'font'
-          %i{:class=>"icon-#{attr :name}", :title=>@caption}
-        - elsif @document.attr? :icons
-          %img{:src=>icon_uri(attr :name), :alt=>@caption}
-        - else
-          .title=@caption
-      %td.content
-        - if title?
-          .title=title
-        =content.chomp
+%div{:id=>@id, :class=>['notes', (attr :name), role]}
+  =content.chomp

--- a/asciidoc/asciidoctor-backends/haml/deckjs/document.html.haml
+++ b/asciidoc/asciidoctor-backends/haml/deckjs/document.html.haml
@@ -39,6 +39,8 @@
     - when 'codemirror'
       %link(rel='stylesheet' href="#{deckjs_dir}/extensions/codemirror/deck.codemirror.css")
       %link(rel='stylesheet' href="#{deckjs_dir}/extensions/codemirror/themes/iq.css")
+      %link(rel='stylesheet' href="#{deckjs_dir}/extensions/clone/deck.clone.css")
+      %link(rel='stylesheet' href="#{deckjs_dir}/extensions/notes/deck.notes.css")
       %script(src="#{deckjs_dir}/extensions/codemirror/codemirror.js")
       %script(src="#{deckjs_dir}/extensions/codemirror/deck.codemirror.js")
       %script(src="#{deckjs_dir}/extensions/codemirror/mode/javascript/javascript.js")
@@ -46,6 +48,8 @@
       %script(src="#{deckjs_dir}/extensions/codemirror/mode/htmlmixed/htmlmixed.js")
       %script(src="#{deckjs_dir}/extensions/codemirror/mode/plsql/plsql.js")
       %script(src="#{deckjs_dir}/extensions/cypher/deck.cypher.js")
+      %script(src="#{deckjs_dir}/extensions/clone/deck.clone.js")
+      %script(src="#{deckjs_dir}/extensions/notes/deck.notes.js")
       %link(rel='stylesheet' href="#{deckjs_dir}/extensions/cypher/deck.cypher.css")
     - when 'prettify'
       %link(rel='stylesheet' href="#{attr :prettifydir, 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/#{attr 'prettify-theme', 'prettify'}.min.css")

--- a/asciidoc/deck.js/extensions/clone/deck.clone.css
+++ b/asciidoc/deck.js/extensions/clone/deck.clone.css
@@ -1,0 +1,35 @@
+body.deck-container.has-clones {
+  /*background: black;*/
+}
+
+.has-clones section.slide.deck-current, .has-clones section.slide.deck-child-current {
+  border: 3px solid gray;
+  transform: scale(0.5) translate(-47%,-50%) translate(30px,30px);
+}
+
+.has-clones section.slide.deck-current + section.slide, .has-clones .slide.deck-child-current + section.slide {
+  top: 0;
+  left: 0;
+  border: 3px solid gray;
+  transform: scale(0.3) translate(55%,-50%) translate(100px,30px);
+  visibility: visible;
+}
+
+.has-clones ul.deck-child-current li.slide.deck-next, .has-clones ul.deck-child-current li.slide.deck-after {
+  color: lightgray;
+  visibility: visible;
+}
+
+.has-clones .notes.note.speaker {
+  display: block !important;
+  bottom: -350px;
+  left: 0;
+  position: absolute;
+  background: transparent;
+  color: black;
+  border: 3px solid gray;
+  width: 100%;
+  font-size: 44px;
+  padding: 12px;
+  overflow: scroll;
+}

--- a/asciidoc/deck.js/extensions/clone/deck.clone.js
+++ b/asciidoc/deck.js/extensions/clone/deck.clone.js
@@ -1,0 +1,74 @@
+/*!
+Deck JS - deck.clone
+Copyright (c) 2011 Remi BARRAQUAND
+Dual licensed under the MIT license and GPL license.
+https://github.com/imakewebthings/deck.js/blob/master/MIT-license.txt
+https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
+*/
+
+/*
+This module provides a support for cloning the deck.
+*/
+
+(function($, deck, undefined) {
+    var $d = $(document);
+    var clones = new Array();
+        
+    $.extend(true, $[deck].defaults, {	
+        keys: {
+            clone: 67 // c
+        }
+    });
+
+    /*
+	jQuery.deck('addClone')
+	
+	Create a clone of this window and add it to the clones list.
+	*/
+    $[deck]('extend', 'addClone', function() {
+        clone = new DeckClone();
+        clones.push(clone);
+        if (clones.length > 0) {
+            $("body").addClass("has-clones");
+        }
+        return clone;
+    });
+        
+    /*
+        jQuery.deck('Init')
+        */
+    $d.bind('deck.init', function() {
+        var opts = $[deck]('getOptions');
+        var container = $[deck]('getContainer');
+        
+        /* Bind key events */
+        $d.unbind('keydown.deckclone').bind('keydown.deckclone', function(e) {
+            if (e.which === opts.keys.clone || $.inArray(e.which, opts.keys.clone) > -1) {
+                $[deck]('addClone');
+                e.preventDefault();
+            }
+        });
+    })
+    /* Update current slide number with each change event */
+    .bind('deck.change', function(e, from, to) {
+        var opts = $[deck]('getOptions');
+        var slideTo = $[deck]('getSlide', to);
+        var container = $[deck]('getContainer');
+	
+        $.each(clones, function(index, clone) {
+           clone.deck('go', to);
+        });
+    });
+    
+    /*
+        Simple Clone manager (must be improved, by for instance adding cloning
+        option e.g. propagate change, etc.)
+        */
+    var DeckClone = function() {
+        var clone = window.open(window.location);
+        
+        this.deck = function() {
+            clone['$'].deck.apply(clone['$'], arguments)
+        }
+    }
+})(jQuery, 'deck');

--- a/asciidoc/deck.js/extensions/notes/deck.notes.css
+++ b/asciidoc/deck.js/extensions/notes/deck.notes.css
@@ -1,0 +1,11 @@
+.notes {
+  position:absolute;
+  z-index:1000;
+  background: black;
+  color: white;
+  opacity :0.8;
+  width : 80%;
+  height: 300px;
+  float: right;
+  overflow: scroll;
+}

--- a/asciidoc/deck.js/extensions/notes/deck.notes.js
+++ b/asciidoc/deck.js/extensions/notes/deck.notes.js
@@ -1,0 +1,53 @@
+/*
+  This module adds support for notes in your deck. 
+  To enable it on your elements add the classname:
+  .notes to a section. To toggle notes press 'n'
+
+  Example:
+  <section class="slide">
+    <h2>Important stuff:</h2>
+    <ul>
+      <li>This stuff is important
+    </ul>
+    <div class="notes">
+      <ul>
+        <li>Tell people: it is important because it is</li>
+      </ul>  
+    <div>
+  <section/>
+*/
+(function($, deck, undefined) {
+
+  var notesDisplayed = false;
+
+  function showNotes(slide) {
+    var notes = slide.find(".notes");
+    notes.each(function(i, note) { $(note).show(); });
+  }
+
+  function toggleNotes(slide) {
+    if (!notesDisplayed) {
+      showNotes(slide);
+      notesDisplayed = true;
+    } else {
+      var notes = slide.find(".notes");
+      notes.each(function(i, note) { $(note).hide(); });
+      notesDisplayed = false;
+    }
+  }
+
+  $(document).bind("deck.change", function(event, from, to) {
+    $(".notes").hide(); //hide all notes
+    if (notesDisplayed) {
+      var slide = $.deck('getSlide', to);
+      showNotes(slide);
+    }
+  });
+
+  $(document).bind("keypress", function(event) {
+    if (event.which == "110") { //'n'
+      toggleNotes($(".deck-current"));
+    }
+  });
+})(jQuery, 'deck', this);
+


### PR DESCRIPTION
After the merge you can hit c character on your keyboard to make a clone window/tab.
The current tab will be used as speaker deck, containing the next slide + notes.

When notes are present add a slide:

```
[NOTE.speaker]
--
Note that the times are approximate. +
We want this class to be a conversation, not a lecture. So we might go longer in some parts, and spend less time on others, or just skip ahead entirely. +
In reality, we'll mostly try to stick to the flow of this deck. +
--
```
